### PR TITLE
Fix websocket transport when connecting non-securely

### DIFF
--- a/lib/client/transport/websocket-transport.ts
+++ b/lib/client/transport/websocket-transport.ts
@@ -28,7 +28,7 @@ export class WebSocketTransport implements Transport {
     this.wsStream = new WebSocketDuplex({
       url: this.config.url,
       decodeStrings: false,
-      objectMode: true,
+      objectMode: false,
     });
     if (connectionListener != null) {
       this.wsStream.once("connect", connectionListener);


### PR DESCRIPTION
This fixes an issue in the Websocket transport preventing it from connecting with the `secure` flag set to `false`.

It ends up failing here, however i do not have the knowledge as to why this does not occur with the `secure` flag to `true`
https://github.com/nodejs/node/blob/7ef5c60e807a94cec70ded9b039a150f048d1f3c/lib/net.js#L352-L356
