### PR TITLE
feat: JoinRateLimiter mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unversioned
+
+- Added JoinRateLimiter mixin.
+
 ## v6.0.0
 
 - Breaking: Removed majority of, since February 18th 2023, deprecated IRC commands.

--- a/README.md
+++ b/README.md
@@ -749,7 +749,7 @@ and the mixins installed by default:
 - `new PrivmsgMessageRateLimiter(client)` - Rate limits outgoing messages
   according to the rate limits imposed by Twitch. Configure the verified/known
   status of your bot using the config (see above).
-- `new ConnectionRateLimiter(client)` - Rate limits new connections accoding to
+- `new ConnectionRateLimiter(client)` - Rate limits new connections according to
   the rate limits set in the config.
 - `new UserStateTracker(client)` - Used by other mixins. Keeps track of what
   state your bot user has in all channels.
@@ -759,6 +759,8 @@ and the mixins installed by default:
   `UnhandledPromiseRejectionWarning`s on promises returned by the client's
   functions. (installed for you if you activate the
   `ignoreUnhandledPromiseRejections` client option)
+- `new JoinRateLimiter(client)` - Rate limits new joins according to join rate
+  limits set in the config.
 
 ## Tests
 

--- a/lib/client/client.ts
+++ b/lib/client/client.ts
@@ -4,6 +4,7 @@ import { ClientMixin, ConnectionMixin } from "../mixins/base-mixin";
 import { IgnoreUnhandledPromiseRejectionsMixin } from "../mixins/ignore-promise-rejections";
 import { ConnectionRateLimiter } from "../mixins/ratelimiters/connection";
 import { PrivmsgMessageRateLimiter } from "../mixins/ratelimiters/privmsg";
+import { JoinRateLimiter } from "../mixins/ratelimiters/join";
 import { RoomStateTracker } from "../mixins/roomstate-tracker";
 import { UserStateTracker } from "../mixins/userstate-tracker";
 import { joinChannel, joinNothingToDo } from "../operations/join";
@@ -53,6 +54,7 @@ export class ChatClient extends BaseClient {
       this.use(new RoomStateTracker());
       this.use(new ConnectionRateLimiter(this));
       this.use(new PrivmsgMessageRateLimiter(this));
+      this.use(new JoinRateLimiter(this));
     }
 
     if (this.configuration.ignoreUnhandledPromiseRejections) {

--- a/lib/config/config.ts
+++ b/lib/config/config.ts
@@ -1,6 +1,6 @@
 import { Duplex } from "stream";
 import { ConnectionRateLimits } from "../mixins/ratelimiters/connection";
-import { MessageRateLimits, PresetKeys } from "./message-rate-limits";
+import { RateLimits, PresetKeys } from "./rate-limits";
 
 export interface DuplexTransportConfiguration {
   type: "duplex";
@@ -42,7 +42,7 @@ export type TransportConfiguration =
   | WebSocketTransportConfiguration
   | PresetWebSocketTransportConfiguration;
 
-export type CustomRateLimitsConfig = MessageRateLimits;
+export type CustomRateLimitsConfig = RateLimits;
 
 // "default" | "knownBot" | "verifiedBot" | { ... } (custom config)
 export type RateLimitsConfig = PresetKeys | CustomRateLimitsConfig;

--- a/lib/config/config.ts
+++ b/lib/config/config.ts
@@ -70,7 +70,7 @@ export interface ClientConfiguration {
   connection?: TransportConfiguration;
 
   /**
-   * Maximum number of channels the client will allow one connection to be joined to. 100 by default.
+   * Maximum number of channels the client will allow one connection to be joined to. 90 by default.
    */
   maxChannelCountPerConnection?: number;
 

--- a/lib/config/expanded.ts
+++ b/lib/config/expanded.ts
@@ -8,10 +8,7 @@ import {
   TransportConfiguration,
   WebSocketTransportConfiguration,
 } from "./config";
-import {
-  messageRateLimitPresets,
-  MessageRateLimits,
-} from "./message-rate-limits";
+import { rateLimitPresets, RateLimits } from "./rate-limits";
 
 export type ExpandedDuplexTransportConfiguration =
   Required<DuplexTransportConfiguration>;
@@ -36,7 +33,7 @@ export type ExpandedClientConfiguration = Required<
 > & {
   password: string | undefined;
   connection: ExpandedTransportConfiguration;
-  rateLimits: MessageRateLimits;
+  rateLimits: RateLimits;
 };
 
 const defaults: Omit<
@@ -120,13 +117,13 @@ export function expandTransportConfig(
 
 export function expandRateLimitsConfig(
   config: RateLimitsConfig | undefined
-): MessageRateLimits {
+): RateLimits {
   if (config == null) {
-    return messageRateLimitPresets.default;
+    return rateLimitPresets.default;
   }
 
   if (typeof config === "string") {
-    return messageRateLimitPresets[config];
+    return rateLimitPresets[config];
   } else {
     return config;
   }

--- a/lib/config/index.ts
+++ b/lib/config/index.ts
@@ -1,3 +1,3 @@
 export * from "./config";
 export * from "./expanded";
-export * from "./message-rate-limits";
+export * from "./rate-limits";

--- a/lib/config/rate-limits.ts
+++ b/lib/config/rate-limits.ts
@@ -1,15 +1,19 @@
-export interface MessageRateLimits {
+export interface RateLimits {
   highPrivmsgLimits: number;
   lowPrivmsgLimits: number;
 
   // whispersPerSecond: number;
   // whispersPerMinute: number;
   // whisperTargetsPerDay: number;
+
+  privmsgInMs: number;
+
+  joinLimits: number;
 }
 
 export type PresetKeys = "default" | "knownBot" | "verifiedBot";
 
-export const messageRateLimitPresets: Record<PresetKeys, MessageRateLimits> = {
+export const rateLimitPresets: Record<PresetKeys, RateLimits> = {
   default: {
     highPrivmsgLimits: 100,
     lowPrivmsgLimits: 20,
@@ -17,6 +21,10 @@ export const messageRateLimitPresets: Record<PresetKeys, MessageRateLimits> = {
     // whispersPerSecond: 3,
     // whispersPerMinute: 100,
     // whisperTargetsPerDay: 40
+
+    privmsgInMs: 35 * 1000,
+
+    joinLimits: 20,
   },
   knownBot: {
     highPrivmsgLimits: 100,
@@ -25,6 +33,10 @@ export const messageRateLimitPresets: Record<PresetKeys, MessageRateLimits> = {
     // whispersPerSecond: 10,
     // whispersPerMinute: 200,
     // whisperTargetsPerDay: 500
+
+    privmsgInMs: 35 * 1000,
+
+    joinLimits: 20,
   },
   verifiedBot: {
     highPrivmsgLimits: 7500,
@@ -33,5 +45,9 @@ export const messageRateLimitPresets: Record<PresetKeys, MessageRateLimits> = {
     // whispersPerSecond: 20,
     // whispersPerMinute: 1200,
     // whisperTargetsPerDay: 100000
+
+    privmsgInMs: 35 * 1000,
+
+    joinLimits: 2000,
   },
 };

--- a/lib/mixins/ratelimiters/index.ts
+++ b/lib/mixins/ratelimiters/index.ts
@@ -1,5 +1,5 @@
 export * from "./connection";
+export * from "./join";
 export * from "./privmsg";
 export * from "./slow-mode";
-export * from "./join";
 export * from "./utils";

--- a/lib/mixins/ratelimiters/index.ts
+++ b/lib/mixins/ratelimiters/index.ts
@@ -1,4 +1,5 @@
 export * from "./connection";
 export * from "./privmsg";
 export * from "./slow-mode";
+export * from "./join";
 export * from "./utils";

--- a/lib/mixins/ratelimiters/join.ts
+++ b/lib/mixins/ratelimiters/join.ts
@@ -1,0 +1,82 @@
+import Semaphore from "semaphore-async-await";
+import { ChatClient } from "../../client/client";
+import { applyReplacements } from "../../utils/apply-function-replacements";
+import { ClientMixin } from "../base-mixin";
+
+export class JoinRateLimiter implements ClientMixin {
+  private readonly client: ChatClient;
+  private readonly joinLimitsSemaphore: Semaphore;
+
+  public constructor(client: ChatClient) {
+    this.client = client;
+
+    this.joinLimitsSemaphore = new Semaphore(
+      this.client.configuration.rateLimits.joinLimits
+    );
+  }
+
+  public applyToClient(client: ChatClient): void {
+    const joinReplacement = async <V, A extends any[]>(
+      oldFn: (channelName: string, ...args: A) => Promise<V>,
+      channelName: string,
+      ...args: A
+    ): Promise<V> => {
+      const releaseFn = await this.acquire();
+      try {
+        return await oldFn(channelName, ...args);
+      } finally {
+        setTimeout(releaseFn, 10 * 1000); // 10 seconds per 20 joined channels.
+      }
+    };
+
+    const joinAllReplacement = async <A extends any[]>(
+      oldFn: (
+        channelNames: string[],
+        ...args: A
+      ) => Promise<Record<string, Error | undefined>>,
+      channelNames: string[],
+      ...args: A
+    ): Promise<Record<string, Error | undefined>> => {
+      const promiseResults = [];
+
+      for (
+        let i = 0;
+        i < channelNames.length;
+        i += this.client.configuration.rateLimits.joinLimits
+      ) {
+        const chunk = channelNames.slice(
+          i,
+          i + this.client.configuration.rateLimits.joinLimits
+        );
+
+        const releaseFns = await Promise.all(
+          Array(chunk.length)
+            .fill(this.acquire)
+            .map((fn) => fn.bind(this)())
+        );
+        try {
+          const promiseRes = await oldFn(chunk, ...args);
+          promiseResults.push(promiseRes);
+        } finally {
+          releaseFns.forEach((releaseFn) => setTimeout(releaseFn, 10 * 1000)); // 10 seconds per 20 joined channels.
+        }
+      }
+
+      return promiseResults.reduce((acc, obj) => ({ ...acc, ...obj }), {});
+    };
+
+    applyReplacements(this, client, {
+      join: joinReplacement,
+      joinAll: joinAllReplacement,
+    });
+  }
+
+  private async acquire(): Promise<() => void> {
+    const releaseFn = (): void => {
+      this.joinLimitsSemaphore.release();
+    };
+
+    await this.joinLimitsSemaphore.acquire();
+    return releaseFn;
+  }
+}

--- a/lib/mixins/ratelimiters/privmsg.ts
+++ b/lib/mixins/ratelimiters/privmsg.ts
@@ -21,7 +21,7 @@ export class PrivmsgMessageRateLimiter implements ClientMixin {
   }
 
   public applyToClient(client: ChatClient): void {
-    const genericReplament = async <V, A extends any[]>(
+    const genericReplacement = async <V, A extends any[]>(
       oldFn: (channelName: string, ...args: A) => Promise<V>,
       channelName: string,
       ...args: A
@@ -30,14 +30,17 @@ export class PrivmsgMessageRateLimiter implements ClientMixin {
       try {
         return await oldFn(channelName, ...args);
       } finally {
-        setTimeout(releaseFn, 35 * 1000);
+        setTimeout(
+          releaseFn,
+          this.client.configuration.rateLimits.privmsgInMs * 1000
+        );
       }
     };
 
     applyReplacements(this, client, {
-      say: genericReplament,
-      me: genericReplament,
-      privmsg: genericReplament,
+      say: genericReplacement,
+      me: genericReplacement,
+      privmsg: genericReplacement,
     });
   }
 

--- a/lib/mixins/ratelimiters/privmsg.ts
+++ b/lib/mixins/ratelimiters/privmsg.ts
@@ -32,7 +32,7 @@ export class PrivmsgMessageRateLimiter implements ClientMixin {
       } finally {
         setTimeout(
           releaseFn,
-          this.client.configuration.rateLimits.privmsgInMs * 1000
+          this.client.configuration.rateLimits.privmsgInMs
         );
       }
     };

--- a/lib/mixins/ratelimiters/privmsg.ts
+++ b/lib/mixins/ratelimiters/privmsg.ts
@@ -30,10 +30,7 @@ export class PrivmsgMessageRateLimiter implements ClientMixin {
       try {
         return await oldFn(channelName, ...args);
       } finally {
-        setTimeout(
-          releaseFn,
-          this.client.configuration.rateLimits.privmsgInMs
-        );
+        setTimeout(releaseFn, this.client.configuration.rateLimits.privmsgInMs);
       }
     };
 

--- a/lib/mixins/ratelimiters/slow-mode.ts
+++ b/lib/mixins/ratelimiters/slow-mode.ts
@@ -21,7 +21,7 @@ export class SlowModeRateLimiter implements ClientMixin {
   }
 
   public applyToClient(client: ChatClient): void {
-    const genericReplament = async <A extends any[]>(
+    const genericReplacement = async <A extends any[]>(
       oldFn: (channelName: string, ...args: A) => Promise<void>,
       channelName: string,
       ...args: A
@@ -41,9 +41,9 @@ export class SlowModeRateLimiter implements ClientMixin {
     };
 
     applyReplacements(this, client, {
-      say: genericReplament,
-      me: genericReplament,
-      privmsg: genericReplament,
+      say: genericReplacement,
+      me: genericReplacement,
+      privmsg: genericReplacement,
     });
 
     if (client.roomStateTracker != null) {


### PR DESCRIPTION
**Adds a default JoinRateLimiter mixin.**

* For join:
https://github.com/KararTY/dank-twitch-irc/pull/11/files#diff-fd8531cf688a1e85a3cbacd87a1341fe7a0d6160c802a44b6419088cd88e9b7cR18-R30
Simply takes a permit from the semaphore, and releases it when join is done.

* For joinAll:
https://github.com/KararTY/dank-twitch-irc/pull/11/files#diff-fd8531cf688a1e85a3cbacd87a1341fe7a0d6160c802a44b6419088cd88e9b7cR32-R66
This PR chunks up the *one initial* joinAll call *into several* joinAll calls based on the limit set in config entry `joinLimits` and then joins their results into one return value for consistency.

Would like some feedback & advice on improving this snippet of code
https://github.com/KararTY/dank-twitch-irc/blob/c7c93010c12623726b2d013869914ba337e12ea1/lib/mixins/ratelimiters/join.ts#L52-L56

Fixes #9 