### PR TITLE
feat: enable autocomplete for event names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unversioned
+
+- Dev: Added TypeScript IDE type hints for event names. (#12)
+
 ## v6.0.0
 
 - Breaking: Removed majority of, since February 18th 2023, deprecated IRC commands.

--- a/lib/client/interface.ts
+++ b/lib/client/interface.ts
@@ -46,7 +46,7 @@ export type TwitchMessageEvents = {
 
 // these are all other messages that are not mapped to twitch messages specifically, e.g. 001
 export interface IRCMessageEvents {
-  [command: string]: [IRCMessage];
+  [command: string & Record<never, never>]: [IRCMessage];
 }
 
 export type ClientEvents = SpecificClientEvents &

--- a/lib/message/parser/twitch-message.ts
+++ b/lib/message/parser/twitch-message.ts
@@ -59,7 +59,7 @@ export const commandClassMap: {
   PONG: typeof PongMessage;
   CAP: typeof CapMessage;
 
-  [key: string]: typeof IRCMessage;
+  [key: string & Record<never, never>]: typeof IRCMessage;
 } = {
   CLEARCHAT: ClearchatMessage,
   CLEARMSG: ClearmsgMessage,


### PR DESCRIPTION
This is a trick to enable intellisense for event names while still being able to pass any string.

Before:
![Code_DG4sVm0qCh](https://user-images.githubusercontent.com/22679886/236406134-89c44f40-0a49-4463-b875-5bc9a381bf3f.png)

After:
![Code_Mpytl7sYkh](https://user-images.githubusercontent.com/22679886/236406187-653eb747-d166-43ca-ab19-9aa86efecc3f.png)

