### PR TITLE
parser: `decodeValue()` Remove `undefined` branch

### DIFF
--- a/lib/message/parser/tags.spec.ts
+++ b/lib/message/parser/tags.spec.ts
@@ -3,9 +3,6 @@ import { decodeValue, parseTags } from "./tags";
 
 describe("./message/parser/tags", function () {
   describe("#decodeValue()", function () {
-    it("should decode undefined as null", function () {
-      assert.isNull(decodeValue(undefined));
-    });
     it("should decode empty string as empty string", function () {
       assert.strictEqual("", decodeValue(""));
     });

--- a/lib/message/parser/tags.ts
+++ b/lib/message/parser/tags.ts
@@ -11,7 +11,7 @@ const decodeMap: Record<string, string> = {
 
 const decodeLookupRegex = /\\\\|\\:|\\s|\\n|\\r|\\/g;
 
-export function decodeValue(value: string) {
+export function decodeValue(value: string): string {
   return value.replace(decodeLookupRegex, (m) => decodeMap[m] || "");
 }
 

--- a/lib/message/parser/tags.ts
+++ b/lib/message/parser/tags.ts
@@ -11,11 +11,7 @@ const decodeMap: Record<string, string> = {
 
 const decodeLookupRegex = /\\\\|\\:|\\s|\\n|\\r|\\/g;
 
-// if value is undefined (no = in tagSrc) then value becomes null
-export function decodeValue(value: string | undefined): string | null {
-  if (value == null) {
-    return null;
-  }
+export function decodeValue(value: string) {
   return value.replace(decodeLookupRegex, (m) => decodeMap[m] || "");
 }
 
@@ -32,6 +28,7 @@ export function parseTags(tagsSrc: string | undefined): IRCMessageTags {
     // ">>>" turns any negative `keyValueDelimiter` into the max uint32, so we get the entire tagSrc for the key.
     const key = tagSrc.slice(0, keyValueDelimiter >>> 0);
 
+    // if there's no = in tagSrc, valueSrc's null
     let valueSrc: string | null = null;
     if (keyValueDelimiter !== -1) {
       valueSrc = decodeValue(tagSrc.slice(keyValueDelimiter + 1));


### PR DESCRIPTION
No longer used
Personally I lean more towards just merging `decodeValue()` and `parseTags()`, Imo, I think `decodeValue()` is a bit redundant, but I do understand if it's there to improve testability.
Either way lmk your preference on this.